### PR TITLE
feat: Actualizar workflow para autocommitear cambios en index.html

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,6 +29,19 @@ jobs:
     - name: Run link generator script
       run: python generate_index_links.py
 
+    - name: Commit and push if changed
+      run: |
+        git config --global user.name 'github-actions[bot]'
+        git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+        git add index.html
+        # Comprobar si hay cambios para commitear
+        if git diff --staged --quiet; then
+          echo "No changes to commit."
+        else
+          git commit -m "docs: Actualizar index.html con nuevos enlaces [skip ci]"
+          git push
+        fi
+
     - name: Setup Pages
       uses: actions/configure-pages@v5
 


### PR DESCRIPTION
Modifica el flujo de trabajo de GitHub (`deploy.yml`) para que, después de generar los enlaces en `index.html`, los cambios se confirmen y se suban automáticamente a la rama `main`.

Esto soluciona el problema de que el `index.html` en el repositorio nunca se actualizaba, aunque la versión desplegada en GitHub Pages sí lo hacía.

Los nuevos pasos añadidos son:
- Configuración de Git con un usuario bot.
- Comprobación de si `index.html` ha sido modificado.
- Commit y push de los cambios a la rama `main`, usando `[skip ci]` para evitar bucles de CI.